### PR TITLE
Bugfix, cmd line flags for disabling web server, init'ing log location, etc.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,7 +123,7 @@ func Scheduler(ctx context.Context, confcomm ConfigChannel, filepath string, del
 	log.Println("[INFO] Starting Scheduler")
 	for {
 		GetLogToFile(ctx, confcomm, filepath)
-		if *startCurrent || *onePass {
+		if *onePass {
 			return
 		}
 		select {
@@ -192,7 +192,7 @@ func GetLog(message chan string, confcomm ConfigChannel, url string, start, end 
 
 	if *startCurrent {
 		confcomm.update <- ep
-		return
+		epconf.Tree_size = ep.Tree_size
 	}
 
 	if epconf.Tree_size < ep.Tree_size {
@@ -254,8 +254,8 @@ func main() {
 	flag.Usage = func() { usage() }
 	disableWebServer = flag.Bool("disable-webserver", false, "Disable built-in webserver.")
 	var DisableAPICertValidation = flag.Bool("disable-cert-validation", false, "Disable validation of CT log API endpoint x.509 certificates (not retrieved certificates).")
-	startCurrent = flag.Bool("start-current", false, "Set current CT log record numbers as starting point in the config. This enables only tracking certificates going forward.")
-	onePass = flag.Bool("one-pass", false, "Collect logs once and exit.")
+	startCurrent = flag.Bool("start-current", false, "Set current CT log record numbers as starting point in the config. This enables only processing newly added certificates.")
+	onePass = flag.Bool("one-pass", false, "Process CT logs until current and exit.")
 	flag.Parse()
 
 	ctl.DisableAPICertValidation = *DisableAPICertValidation

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -126,6 +126,10 @@ func Scheduler(ctx context.Context, confcomm ConfigChannel, filepath string, del
 		if *onePass {
 			return
 		}
+
+		// At this point the config values should be set correctly. Setting
+		// startCurrent to false will stop this from happening every loop.
+		*startCurrent = false
 		select {
 		case <-time.After(delay):
 		}


### PR DESCRIPTION
I apologize making multiple changes in one PR  but they all depended on implementing command line flags.  This PR:

### Bug fix
1. Fixes a bug in `loadConfig` where it was trying to open a file named `filename` instead of the one one specified in the variable `filename`. This resulted in an empty config at every launch.

### New Features

1. Adds command line flags and usage information
    1.  Adds a flag, `--disable-webserver`, to prevent the web server from launching. This is useful in the headless environment we run.
        1.  There is now also logging to indicate if the web server is listening and, if so, on what port.
    1.  Adds a flag, `--start-current`, to set the log position (next log to entry to download) to the highest entry in the log. This will cause the code to process all future log entries instead of starting from `0` or the previous stop point.
    1.  Add a flag, `--one-pass`, which causes the code to process logs until it is caught up and then exits.  It effectively disables the Scheduler timer.
    1.  Add a flag, `--disable-cert-validation`, that disables validation of the TLS certificates provided by the CT Log API endpoints.  This is done so that the code can pull logs from endpoints that don't provide certificates that are valid.

```bash
go run main.go -h
Usage: cmd [options]

Connects to public CT logs, downloads records, and extracts potential hostnames.

Results are accessible via the file system or a built-in web server on port :3000

Options:
  -disable-cert-validation
    	Disable validation of CT log API endpoint x.509 certificates (not retrieved certificates).
  -disable-webserver
    	Disable built-in webserver.
  -one-pass
    	Collect logs once and exit.
  -start-current
    	Set current CT log record numbers as starting point in the config. This enables only tracking certificates going forward.
```

### Architectural changes

  1.  `Scheduler` no longer returns an anonymous go-routine. This was done as part of the efforts to allow a single pass through the logs or an immediate exit for `start-current`. Additionally, I could not find a way to leverage the `stop` channel in manner that changed the state of `Scheduler`.  It is now one of the few sections of code that is not a go-routine.

  1. The web server, if enabled, is now a go-routine (effectively switching places with `Scheduler` as the primary function)
 
#### Testing

Web server - verify that
- [ ] `--disable-webserver` prevents the server from listening and the state is logged.
- [ ] Without `--disable-webserver` the web server starts listening and the state is logged.

Start current
- [ ] Delete the config file
- [ ] Use `--start-current` to initialize the state to the current end of the CT logs.
- [ ] Review the `config.json` file and verify that the `tree_size` value for the logs looks appropriate.
- [ ] Wait  the `delay` time (5 minutes) and verify that the log processing starts at the correct location for each log.
- [ ] Close the program. Wait a few minutes and then run without `--start-current` and verify that the log processing starts at the correct location for each log.

One pass
- [ ] Use `--one-pass` and verify that the code processes logs until current and then exits.

Certificate validation
- [ ] Use `--disable-cert-validation` and verify that there are **no** x.509 validation warnings.
- [ ] Without `--disable-cert-validation` verify that there are x.509 validation warnings.