### PR TITLE
Tune file handles

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ import (
 )
 
 const listenPort = ":3000"
-const PAGESIZE = 300
 const CONFIGFILE = "config.json"
 
 var disableWebServer *bool
@@ -200,17 +199,19 @@ func GetLog(message chan string, confcomm ConfigChannel, url string, start, end 
 		epconf.Tree_size = ep.Tree_size
 	}
 
-	if epconf.Tree_size < ep.Tree_size {
-		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size, PAGESIZE)
+	// Tree_size is a count of available records but the request is indexed
+	// from 0 so if we request the end as ep.Tree_size most logs will return
+	// an error instead of just returning the last record.
+	for epconf.Tree_size < ep.Tree_size-1 {
+		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size)
 		if err != nil {
 			log.Println(err)
 		}
-		ep.Tree_size = epconf.Tree_size + sum
-
+		epconf.Tree_size += sum
+		confcomm.update <- &epconf
 	}
-	confcomm.update <- ep
-	log.Printf("[INFO] Closing goroutine for %s\n", url)
 
+	log.Printf("[INFO] Closing goroutine for %s\n", url)
 }
 
 func realmain() error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"syscall"
 	"time"
 
 	ctl "github.com/GovAuCSU/ctlog-acquisition"
@@ -252,6 +253,45 @@ func realmain() error {
 	return nil
 }
 
+// increaseOpenFilesLimit ensures that the code has sufficient file descriptors
+// to operate. In current versions of go (1.11 and earlier) DNS requests use
+// one FD per request and, when combined with the HTTP requests, can cause
+// name resolution errors even for servers another goroutine is already connected
+// to.
+func increaseOpenFilesLimit() {
+
+	var minOpenFileLimit = 2048
+	var rLimit syscall.Rlimit
+
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		log.Println("[ERROR] Unable to determine max open file descriptors: ", err)
+		return
+	}
+
+	var origLimit = rLimit
+	var updated = false
+
+	if rLimit.Cur < uint64(minOpenFileLimit) {
+		rLimit.Cur = uint64(minOpenFileLimit)
+		updated = true
+	}
+
+	if rLimit.Max < uint64(minOpenFileLimit) {
+		rLimit.Max = uint64(minOpenFileLimit)
+		updated = true
+	}
+
+	if updated {
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			log.Println("[ERROR] Error while changing max open file descriptors: ", err)
+		}
+		log.Printf("[INFO] Changed max open file descriptors from %d (%d) to %d (%d)", origLimit.Cur, origLimit.Max, rLimit.Cur, rLimit.Max)
+
+	}
+}
+
 // Neat trick to consistently handling error
 func main() {
 
@@ -263,6 +303,8 @@ func main() {
 	flag.Parse()
 
 	ctl.DisableAPICertValidation = *DisableAPICertValidation
+
+	increaseOpenFilesLimit()
 
 	err := realmain()
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -286,6 +286,7 @@ func increaseOpenFilesLimit() {
 		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 		if err != nil {
 			log.Println("[ERROR] Error while changing max open file descriptors: ", err)
+			return
 		}
 		log.Printf("[INFO] Changed max open file descriptors from %d (%d) to %d (%d)", origLimit.Cur, origLimit.Max, rLimit.Cur, rLimit.Max)
 

--- a/stream.go
+++ b/stream.go
@@ -59,26 +59,24 @@ func Newendpoint(path string) (*Endpoint, error) {
 
 }
 
-// StreamLog connects to the Downloadurl of the specified endpoint, requests
-// the records between start and end (inclusively), extracts the potential
-// hostnames, sends the hostnames down the 'message' channel, and returns
-// the number of log entry records retrieved.
-func (ep *Endpoint) StreamLog(message chan string, start, end int) (int, error) {
+func (ep *Endpoint) StreamLog(message chan string, start, end, pagesize int) (int, error) {
 	size := end - start
 	if size <= 0 {
 		return 0, fmt.Errorf("[ERROR] StreamLog : End should be larger than start")
 	}
 
-	log.Printf("[INFO] Getting log from %s:%d --> %d\n", ep.Downloadurl, start, end)
-	resp, err := httpclient.Get(ep.Downloadurl + fmt.Sprintf("?start=%d&end=%d", start, end))
+	t := end
+	if start+pagesize < end {
+		t = start + pagesize
+	}
+	resp, err := httpclient.Get(ep.Downloadurl + fmt.Sprintf("?start=%d&end=%d", start, t))
 	if err != nil {
 		return 0, err
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		return 0, fmt.Errorf("[DEBUG] Got wrong status code for %s: StatusCode: %d Body: %s", ep.Downloadurl, resp.StatusCode, bodyBytes)
+		return 0, fmt.Errorf("[DEBUG] Got wrong status code for %s: %d", ep.Downloadurl, resp.StatusCode)
 	}
 
 	var leaves struct {
@@ -110,6 +108,16 @@ func (ep *Endpoint) StreamLog(message chan string, start, end int) (int, error) 
 		}
 
 	}
+	sumrecord := responselength
+	// If there are still more records,
+	if (responselength < size) && (t < end) {
+		log.Printf("[WARN] Getting more log from %s:%d --> %d with pagesize %d\n", ep.Downloadurl, start+responselength, end, responselength)
+		s, err := ep.StreamLog(message, start+responselength, end, responselength)
+		if err != nil {
+			return sumrecord, err
+		}
+		sumrecord = sumrecord + s
+	}
+	return sumrecord, nil
 
-	return responselength, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -27,18 +27,18 @@ type Endpoint struct {
 	Tree_head_signature string `json:"tree_head_signature"`
 }
 
+var tr = &http.Transport{
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
+}
+
+var httpclient = http.Client{
+	Timeout:   time.Second * 10, // Timeout after 10 secs timeout
+	Transport: tr,
+}
+
 func Newendpoint(path string) (*Endpoint, error) {
 	infourl := PROTOCOL + path + INFOURI
 	downloadurl := PROTOCOL + path + DOWNLOADURI
-
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
-	}
-
-	httpclient := http.Client{
-		Timeout:   time.Second * 10, // Timeout after 10 secs timeout
-		Transport: tr,
-	}
 
 	resp, err := httpclient.Get(infourl)
 	if err != nil {
@@ -64,15 +64,7 @@ func (ep *Endpoint) StreamLog(message chan string, start, end, pagesize int) (in
 	if size <= 0 {
 		return 0, fmt.Errorf("[ERROR] StreamLog : End should be larger than start")
 	}
-	// Using http.Client so we can modify timeout value
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
-	}
 
-	httpclient := http.Client{
-		Timeout:   time.Second * 10, // Timeout after 30 secs timeout
-		Transport: tr,
-	}
 	t := end
 	if start+pagesize < end {
 		t = start + pagesize

--- a/stream.go
+++ b/stream.go
@@ -27,18 +27,18 @@ type Endpoint struct {
 	Tree_head_signature string `json:"tree_head_signature"`
 }
 
-var tr = &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
-}
-
-var httpclient = http.Client{
-	Timeout:   time.Second * 10, // Timeout after 10 secs timeout
-	Transport: tr,
-}
-
 func Newendpoint(path string) (*Endpoint, error) {
 	infourl := PROTOCOL + path + INFOURI
 	downloadurl := PROTOCOL + path + DOWNLOADURI
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
+	}
+
+	httpclient := http.Client{
+		Timeout:   time.Second * 10, // Timeout after 10 secs timeout
+		Transport: tr,
+	}
 
 	resp, err := httpclient.Get(infourl)
 	if err != nil {
@@ -64,7 +64,15 @@ func (ep *Endpoint) StreamLog(message chan string, start, end, pagesize int) (in
 	if size <= 0 {
 		return 0, fmt.Errorf("[ERROR] StreamLog : End should be larger than start")
 	}
+	// Using http.Client so we can modify timeout value
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
+	}
 
+	httpclient := http.Client{
+		Timeout:   time.Second * 10, // Timeout after 30 secs timeout
+		Transport: tr,
+	}
 	t := end
 	if start+pagesize < end {
 		t = start + pagesize


### PR DESCRIPTION
This program can consume a high number of file descriptors due to it's nature. Unfortunately, the Golang DNS stub resolver uses per-query DNS transports that can consume more descriptors than necessary ( See https://github.com/golang/go/issues/23866 ).   This is further compounded when running on macOS where the default soft limit is 256. The result is that the code can generate `dial tcp: lookup your.hostname.here: no such host` messages even for **hosts it is currently connected to**.

Here is an example of the log output where this has impacted connections to `argon2018` and `nimbus2018` logs.  As you can see, the code was communicating correctly and then less than a second later it cannot resolve the hostname.  I've removed other log entries that aren't related to make this more consumable. 

```
2018/09/21 08:52:04 [WARN] Getting more log from https://ct.googleapis.com/logs/argon2018/ct/v1/get-entries:400318168 --> 401651252 with pagesize 256
https://ct.googleapis.com/logs/argon2018/ct/v1/get-entries:400318424 --> 401651252 with pagesize 256
2018/09/21 08:52:06 [WARN] Getting more log from https://ct.cloudflare.com/logs/nimbus2018/ct/v1/get-entries:253417924 --> 253959981 with pagesize 316
2018/09/21 08:52:07 [WARN] Getting more log from https://ct.googleapis.com/logs/argon2018/ct/v1/get-entries:400318680 --> 401651252 with pagesize 256
2018/09/21 08:52:07 [WARN] Getting more log from https://ct.cloudflare.com/logs/nimbus2018/ct/v1/get-entries:253418241 --> 253959981 with pagesize 317
2018/09/21 08:52:07 Get https://ct.cloudflare.com/logs/nimbus2018/ct/v1/get-entries?start=253418241&end=253418558: dial tcp: lookup ct.cloudflare.com: no such host
2018/09/21 08:52:07 [INFO] Closing goroutine for ct.cloudflare.com/logs/nimbus2018/
2018/09/21 08:52:07 Get https://ct.googleapis.com/logs/argon2018/ct/v1/get-entries?start=400318680&end=400318936: dial tcp: lookup ct.googleapis.com: no such host
```

**NOTE:** `Endpoint.StreamLog` is being called recursively which is adding to resource consumption. I've seen a recursion depth of > 266 in just a few minutes of operation.   I expect to PR a fix for this later today. 

This PR:
1. Introduces `increaseOpenFilesLimit` which determines if the soft and hard file descriptor limits are below the threshold, in this case 2048, and attempts to increase only as needed.  It will not exit the application if this is not possible.  The limits are scoped to the running program and leave no lasting impact on the operating environment. 
