### PR TITLE
Remove recursive call to Endpoint.Streamlog

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,7 +202,7 @@ func GetLog(message chan string, confcomm ConfigChannel, url string, start, end 
 	// from 0 so if we request the end as ep.Tree_size most logs will return
 	// an error instead of just returning the last record.
 	for epconf.Tree_size < ep.Tree_size-1 {
-		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size)
+		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size-1)
 		if err != nil {
 			log.Println(err)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,6 @@ import (
 )
 
 const listenPort = ":3000"
-const PAGESIZE = 300
 const CONFIGFILE = "config.json"
 
 var disableWebServer *bool
@@ -199,17 +198,19 @@ func GetLog(message chan string, confcomm ConfigChannel, url string, start, end 
 		epconf.Tree_size = ep.Tree_size
 	}
 
-	if epconf.Tree_size < ep.Tree_size {
-		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size, PAGESIZE)
+	// Tree_size is a count of available records but the request is indexed
+	// from 0 so if we request the end as ep.Tree_size most logs will return
+	// an error instead of just returning the last record.
+	for epconf.Tree_size < ep.Tree_size-1 {
+		sum, err := ep.StreamLog(message, epconf.Tree_size, ep.Tree_size)
 		if err != nil {
 			log.Println(err)
 		}
-		ep.Tree_size = epconf.Tree_size + sum
-
+		epconf.Tree_size += sum
+		confcomm.update <- &epconf
 	}
-	confcomm.update <- ep
-	log.Printf("[INFO] Closing goroutine for %s\n", url)
 
+	log.Printf("[INFO] Closing goroutine for %s\n", url)
 }
 
 func realmain() error {

--- a/stream.go
+++ b/stream.go
@@ -27,18 +27,18 @@ type Endpoint struct {
 	Tree_head_signature string `json:"tree_head_signature"`
 }
 
+var tr = &http.Transport{
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
+}
+
+var httpclient = http.Client{
+	Timeout:   time.Second * 10, // Timeout after 10 secs timeout
+	Transport: tr,
+}
+
 func Newendpoint(path string) (*Endpoint, error) {
 	infourl := PROTOCOL + path + INFOURI
 	downloadurl := PROTOCOL + path + DOWNLOADURI
-
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
-	}
-
-	httpclient := http.Client{
-		Timeout:   time.Second * 10, // Timeout after 10 secs timeout
-		Transport: tr,
-	}
 
 	resp, err := httpclient.Get(infourl)
 	if err != nil {
@@ -59,32 +59,27 @@ func Newendpoint(path string) (*Endpoint, error) {
 
 }
 
-func (ep *Endpoint) StreamLog(message chan string, start, end, pagesize int) (int, error) {
+// StreamLog connects to the Downloadurl of the specified endpoint, requests
+// the records between start and end (inclusively), extracts the potential
+// hostnames, sends the hostnames down the 'message' channel, and returns
+// the number of log entry records retrieved.
+func (ep *Endpoint) StreamLog(message chan string, start, end int) (int, error) {
 	size := end - start
 	if size <= 0 {
 		return 0, fmt.Errorf("[ERROR] StreamLog : End should be larger than start")
 	}
-	// Using http.Client so we can modify timeout value
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: DisableAPICertValidation},
-	}
 
-	httpclient := http.Client{
-		Timeout:   time.Second * 10, // Timeout after 30 secs timeout
-		Transport: tr,
-	}
-	t := end
-	if start+pagesize < end {
-		t = start + pagesize
-	}
-	resp, err := httpclient.Get(ep.Downloadurl + fmt.Sprintf("?start=%d&end=%d", start, t))
+	log.Printf("[INFO] Getting log from %s:%d --> %d\n", ep.Downloadurl, start, end)
+	resp, err := httpclient.Get(ep.Downloadurl + fmt.Sprintf("?start=%d&end=%d", start, end))
+
 	if err != nil {
 		return 0, err
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("[DEBUG] Got wrong status code for %s: %d", ep.Downloadurl, resp.StatusCode)
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		return 0, fmt.Errorf("[DEBUG] Got wrong status code for %s: Code: %d Body: %q", ep.Downloadurl, resp.StatusCode, bodyBytes)
 	}
 
 	var leaves struct {
@@ -116,16 +111,5 @@ func (ep *Endpoint) StreamLog(message chan string, start, end, pagesize int) (in
 		}
 
 	}
-	sumrecord := responselength
-	// If there are still more records,
-	if (responselength < size) && (t < end) {
-		log.Printf("[WARN] Getting more log from %s:%d --> %d with pagesize %d\n", ep.Downloadurl, start+responselength, end, responselength)
-		s, err := ep.StreamLog(message, start+responselength, end, responselength)
-		if err != nil {
-			return sumrecord, err
-		}
-		sumrecord = sumrecord + s
-	}
-	return sumrecord, nil
-
+	return responselength, nil
 }


### PR DESCRIPTION

Remove recursive call to Endpoint.Streamlog


#### Issue
`Endpoint.StreamLog` calls it self recursively until all of the log entries have been retrieved. This can be problematic when the process has thousand or entries to retrieve.

Example output after adding a `depth` marker to the `Endpoint.StreamLog` function. This particular process had only been running for a couple of minutes and we had reached a depth of 228 on the `skydiver` log.

```
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/skydiver/ct/v1/get-entries:44137203 --> 44147069 with pagesize 526
2018/09/21 08:45:41 Url: ct.googleapis.com/skydiver/ Depth: 226
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/pilot/ct/v1/get-entries:377692723 --> 378423985 with pagesize 467
2018/09/21 08:45:41 Url: ct.googleapis.com/pilot/ Depth: 167
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/rocketeer/ct/v1/get-entries:429082246 --> 430148498 with pagesize 360
2018/09/21 08:45:41 Url: ct.googleapis.com/rocketeer/ Depth: 60
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/skydiver/ct/v1/get-entries:44137730 --> 44147069 with pagesize 527
2018/09/21 08:45:41 Url: ct.googleapis.com/skydiver/ Depth: 227
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/icarus/ct/v1/get-entries:368633585 --> 369276926 with pagesize 492
2018/09/21 08:45:41 Url: ct.googleapis.com/icarus/ Depth: 192
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/logs/argon2018/ct/v1/get-entries:400339928 --> 401642139 with pagesize 256
2018/09/21 08:45:41 Url: ct.googleapis.com/logs/argon2018/ Depth: 99
2018/09/21 08:45:41 [WARN] Getting more log from https://ct.googleapis.com/skydiver/ct/v1/get-entries:44138258 --> 44147069 with pagesize 528
2018/09/21 08:45:41 Url: ct.googleapis.com/skydiver/ Depth: 228
```

### Changes

The logic was changed so that `GetLog` in `main`  repeatedly calls `Endpoint.StreamLog` until reaching the end of the CT Log.  It updates the state  between each loop so that if the process is killed in mid loop the log position is not lost.

Also, PAGESIZE has been removed as it was no longer required.  The current code requests all records from `start` to `end` and the CT Log server will return this amount up to it's configured limit.  For Google servers this appears to be 256 and the maximum number I've seen returned as 1001. This seems to fall within a reasonable size, particularly after removing the recursion.


**Note:** This PR also moves the `httpclient` and related Transport to the package level. These constructs are safe for concurrency and reuse should improve socket reuse and resource usage in general.