### PR TITLE
Use new Google log list and json schema

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -179,13 +179,14 @@ func realGetLogToFile(ctx context.Context, confcomm configChannel, start, end in
 	_ = ctlist
 	var wg sync.WaitGroup
 
-	// Starting one thread per CT Log api endpoint
-	for _, l := range ctlist.Logs {
-		if l.Disqualified > 0 {
-			continue
+	// Starting one thread per CT Operator/Log api endpoint
+	for _, operator := range ctlist.Operators {
+		log.Printf("[INFO] Acquiring logs for Operator: %s\n", operator.Name)
+
+		for _, log := range operator.Logs {
+			wg.Add(1)
+			go getLog(msg, confcomm, log.Url, start, end, &wg)
 		}
-		wg.Add(1)
-		go getLog(msg, confcomm, l.Url, start, end, &wg)
 	}
 
 	wg.Wait()

--- a/ctlist.go
+++ b/ctlist.go
@@ -8,25 +8,22 @@ import (
 )
 
 type ctlist struct {
-	Logs      []ctlistendpoint `json:"logs"`
 	Operators []operator       `json:"operators"`
 }
 type ctlistendpoint struct {
 	Description         string `json:"description"`
 	Key                 string `json:"key"`
 	Url                 string `json:"url"`
-	Disqualified        int    `json:"disqualified_at"`
-	Maximum_merge_delay int    `json:"maximum_merge_delay"`
-	Operated_by         []int  `json:"operated_by"`
 }
 
 type operator struct {
 	Name string `json:"name"`
 	Id   int    `json:"id"`
+	Logs []ctlistendpoint `json:"logs"`
 }
 
 func GetListCT() (*ctlist, error) {
-	url := "https://www.gstatic.com/ct/log_list/log_list.json"
+	url := "https://www.gstatic.com/ct/log_list/v3/log_list.json"
 	// Using http.Client so we can modify timeout value
 	httpclient := http.Client{
 		Timeout: time.Second * 2, // Maximum of 2 secs timeout

--- a/stream.go
+++ b/stream.go
@@ -10,7 +10,6 @@ import (
 	"time"
 )
 
-const PROTOCOL = "https://"
 const INFOURI = "ct/v1/get-sth"
 const DOWNLOADURI = "ct/v1/get-entries"
 
@@ -37,8 +36,8 @@ var httpclient = http.Client{
 }
 
 func Newendpoint(path string) (*Endpoint, error) {
-	infourl := PROTOCOL + path + INFOURI
-	downloadurl := PROTOCOL + path + DOWNLOADURI
+	infourl := path + INFOURI
+	downloadurl := path + DOWNLOADURI
 
 	resp, err := httpclient.Get(infourl)
 	if err != nil {


### PR DESCRIPTION
The v3 log list from Google changed the JSON structure so this PR updates it to fetch properly.  Please note, this also changes the config files, because the config keys and `Url` fields previously did not include the protocol `https://` but this now comes from the Google JSON list.  I didn't adapt it because I believe including the protocol is more correct anyway.  So users that want to use an old config file will just have to add the protocol in front. 

Example: 

```
    "https://ct.googleapis.com/logs/argon2024/": {
      "Url": "https://ct.googleapis.com/logs/argon2024/",
      "download_url": "https://ct.googleapis.com/logs/argon2024/ct/v1/get-entries",
      "info_url": "https://ct.googleapis.com/logs/argon2024/ct/v1/get-sth",
      "sha256_root_hash": "Y7Ov9NTOzmrMb+a95JHk4Qt8mYuhQQouWdzNPVr/hEw=",
      "timestamp": 1632148795983,
      "tree_head_signature": "BAMASDBGAiEA26ATA72G0Mu3cINYSsM11mwekPuomV1kEpEEQzCFb2MCIQCe92f45QL3yHQAz3CmZgGQKgSakssJ5gJtoDA0aBdSCQ==",
      "tree_size": 7286131
    },
```